### PR TITLE
Changed span id to capture correct price

### DIFF
--- a/amazonstoreprice/amazonstoreprice.py
+++ b/amazonstoreprice/amazonstoreprice.py
@@ -69,4 +69,4 @@ class AmazonStorePrice:
         :return: float(price cleaned)
         """
         body_content = self.getpage(self.normalizeurl(url), retry_ontemp=retry_ontemp)
-        return self.normalizeprice(body_content.find("span", {"class": "a-color-price"}).contents[0])
+        return self.normalizeprice(body_content.find("span", {"class": "a-size-base a-color-price"}).contents[0])


### PR DESCRIPTION
The span ID of the product price has probably changed because the previous ID returned a different amount (of an add-on product showing in suggestions). Hence, just updated the span id to find in the getprice function.